### PR TITLE
Fix Mint installation failure in CI linting job

### DIFF
--- a/.github/workflows/BushelKit.yml
+++ b/.github/workflows/BushelKit.yml
@@ -166,24 +166,30 @@ jobs:
       MINT_LINK_PATH: .mint/bin
     steps:
       - uses: actions/checkout@v4    
-      - name: Cache mint
+      - name: Restore mint cache
         id: cache-mint
-        uses: actions/cache@v4  
-        env:
-          cache-name: cache
+        uses: actions/cache/restore@v4
         with:
           path: |
             .mint
-            Mint         
+            Mint
           key: ${{ runner.os }}-mint-${{ hashFiles('**/Mintfile') }}
           restore-keys: |
             ${{ runner.os }}-mint-  
       - name: Install mint
-        if: steps.cache-mint.outputs.cache-hit != 'true'
+        if: steps.cache-mint.outputs.cache-matched-key == ''
         run: |
           git clone https://github.com/yonaskolb/Mint.git
           cd Mint
           swift run mint install yonaskolb/mint
+      - name: Save mint cache
+        if: steps.cache-mint.outputs.cache-matched-key == ''
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            .mint
+            Mint
+          key: ${{ runner.os }}-mint-${{ hashFiles('**/Mintfile') }}
       - name: Lint
         run: ./Scripts/lint.sh
 


### PR DESCRIPTION
## Summary
- Replace `actions/cache@v4` with separate `actions/cache/restore@v4` and `actions/cache/save@v4` actions
- Update Install mint step condition to use `cache-matched-key` output
- Add Save mint cache step to save cache only when building from scratch

## Problem
The linting job was failing with exit code 128 during the "Install mint" step. The root cause was that the cache action's `restore-keys` fallback would restore a partial cache (old `Mint/` directory), but `cache-hit` would return `'false'` since it wasn't an exact match. This caused the Install step to run and attempt `git clone`, which failed because the directory already existed.

## Solution
Using separate restore/save actions provides the `cache-matched-key` output, which is:
- Empty string when NO cache was restored → Install and Save run
- Has a value when ANY cache restored (exact or partial) → Install and Save skipped

This allows the workflow to reuse fallback caches instead of unnecessarily rebuilding Mint.

## Test plan
- [ ] Verify CI linting job passes on this PR
- [ ] Verify cache is properly saved after first successful run
- [ ] Verify subsequent runs with exact cache match skip Install/Save steps
- [ ] Verify runs with partial cache match (when Mintfile changes) skip Install/Save steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- GitContextStart -->
- - -
Perform an AI-assisted review on [<img src="https://codepeer.com/logo/CodePeerButton.svg" height="32" align="absmiddle" alt="CodePeer.com"/>](https://codepeer.com/app/prs/github/brightdigit/BushelKit/123)
<!-- GitContextEnd -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added enhanced console output capabilities with verbose mode, info, success, warning, and error logging functions.
  * Introduced data source configuration management with environment-based fetch intervals and throttling controls.

* **Chores**
  * Updated development tooling: Added Swift 6.3 support, removed Swift 6.1.
  * Updated dependencies: SwiftLint 0.61.0 → 0.62.2; multiple Swift packages (argument-parser, collections, http-types, log, openapi-runtime, openapi-urlsession).
  * Optimized Xcode launch configuration and GitHub Actions caching.

* **Tests**
  * Added comprehensive test coverage for new data source handling, fetch configuration, console output, and JSON decoding features.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->